### PR TITLE
Add support for AMD and Node/CommonJS module system

### DIFF
--- a/Leaflet.PolylineMeasure.js
+++ b/Leaflet.PolylineMeasure.js
@@ -1,4 +1,20 @@
-(function() {
+(function (factory) {
+    var L;
+    if (typeof define === 'function' && define.amd) {
+        // AMD
+        define(['leaflet'], factory);
+    } else if (typeof module !== 'undefined') {
+        // Node/CommonJS
+        L = require('leaflet');
+        module.exports = factory(L);
+    } else {
+        // Browser globals
+        if (typeof window.L === 'undefined') {
+            throw new Error('Leaflet must be loaded first');
+        }
+        factory(window.L);
+    }
+}(function (L) {
 
 	var _measureControlId = 'polyline-measure-control';
 	var _unicodeClass = 'polyline-measure-unicode-icon';
@@ -820,4 +836,4 @@
 	L.control.polylineMeasure = function (options) {
 		return new L.Control.PolylineMeasure (options);
 	};
-})();
+}));

--- a/Leaflet.PolylineMeasure.js
+++ b/Leaflet.PolylineMeasure.js
@@ -1,12 +1,10 @@
 (function (factory) {
-    var L;
     if (typeof define === 'function' && define.amd) {
         // AMD
         define(['leaflet'], factory);
     } else if (typeof module !== 'undefined') {
         // Node/CommonJS
-        L = require('leaflet');
-        module.exports = factory(L);
+        module.exports = factory(require('leaflet'));
     } else {
         // Browser globals
         if (typeof window.L === 'undefined') {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "leaflet.polylinemeasure",
+  "version": "1.0.0",
+  "description": "Leaflet Plugin to measure distances of simple lines as well as of complex polylines",
+  "main": "Leaflet.PolylineMeasure.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ppete2/Leaflet.PolylineMeasure.git"
+  },
+  "author": "",
+  "license": "BSD-2-Clause",
+  "bugs": {
+    "url": "https://github.com/ppete2/Leaflet.PolylineMeasure/issues"
+  },
+  "homepage": "https://github.com/ppete2/Leaflet.PolylineMeasure#readme"
+}


### PR DESCRIPTION
If leaflet is used with a module system, a packager like webpack cannot resolve the dependencies if this plugin has no support for it. As a result, the plugin cannot be used as the script loading order cannot be determined.

This pull request adds support for the AMD and Node/CommonJS module systems.