### PR TITLE
Bugfixes: _finishPath called with no event; no events unsubscription on control remove

### DIFF
--- a/Leaflet.PolylineMeasure.js
+++ b/Leaflet.PolylineMeasure.js
@@ -373,6 +373,13 @@
         },
 
         /**
+         * Method to fire on remove from map
+         */
+        onRemove: function () {
+            if (self._measuring) self._toggleMeasure();
+        },
+
+        /**
          * Toggle the measure functionality on or off
          * @private
          */

--- a/Leaflet.PolylineMeasure.js
+++ b/Leaflet.PolylineMeasure.js
@@ -418,7 +418,7 @@
          */
         _clearAllMeasurements: function() {
             if ((self._cntCircle !== undefined) && (self._cntCircle !== 0)) {
-                    self._finishPath();
+                self._finishPath();
             }
             if (self._layerPaint) {
                 self._layerPaint.clearLayers();
@@ -812,7 +812,7 @@
          */
         _finishPath: function(e) {
             self._currentLine.finalize();
-            self._finishPoint = e.containerPoint;
+            if (e) self._finishPoint = e.containerPoint;
         },
 
         /**


### PR DESCRIPTION
There's a few calls of `_finishPath` with no parameters which causes `Uncaught TypeError: Cannot read property 'containerPoint' of undefined`.

The second issue is that if we remove the control in a measuring state, it'll left some listeners subscribed. For example `_mouseMove` will fire an error on every move cuz there won't be any `self._map`.