### PR TITLE
[fix] reflect change of signature

### DIFF
--- a/Leaflet.PolylineMeasure.js
+++ b/Leaflet.PolylineMeasure.js
@@ -438,7 +438,7 @@
                 }
                 // to remove temp. Line if line at the moment is being drawn and not finished while clicking the control
                 if (this._cntCircle !== 0) {
-                    this._finishOrRestartPath();
+                    this._finishPolylinePath();
                 }
             }
         },
@@ -448,7 +448,7 @@
          */
         _clearAllMeasurements: function() {
             if ((this._cntCircle !== undefined) && (this._cntCircle !== 0)) {
-                    this._finishOrRestartPath();
+                    this._finishPolylinePath();
             }
             if (this._layerPaint) {
                 this._layerPaint.clearLayers();


### PR DESCRIPTION
In the commit https://github.com/ppete2/Leaflet.PolylineMeasure/commit/e7dfe4fa84c5ca3f6e56c6487948b173d9172f9c the `_finishOrRestartPath` method was migrated to `_finishPolylinePath` but somehow the change was lost