### PR TITLE
Fire events on control actions.

### DIFF
--- a/Leaflet.PolylineMeasure.js
+++ b/Leaflet.PolylineMeasure.js
@@ -515,6 +515,7 @@
                 this._layerPaint.clearLayers();
             }
             this._arrPolylines = [];
+            this._map.fire('polylinemeasure:clear');
         },
 
         _changeUnit: function() {
@@ -954,10 +955,12 @@
 
             if (!this._currentLine && !this._mapdragging) {
                 this._startLine (e.latlng);
+                this._map.fire('polylinemeasure:start', this._currentLine);
             }
             // just create a point if the map isn't dragged during the mouseclick.
             if (!this._mapdragging) {
                 this._currentLine.addPoint (e.latlng);
+                this._map.fire('polylinemeasure:add', e);
             } else {
                 this._mapdragging = false; // this manual setting to "false" needed, instead of a "moveend"-Event. Cause the mouseclick of a "moveend"-event immediately would create a point too the same time.
             }
@@ -968,6 +971,7 @@
          * @private
          */
         _finishPolylinePath: function (e) {
+            this._map.fire('polylinemeasure:finish', this._currentLine);
             this._currentLine.finalize();
             if (e) {
                 this._finishCircleScreencoords = e.containerPoint;
@@ -996,6 +1000,7 @@
                 this._currentLine.circleMarkers.last().bindTooltip (this.options.tooltipTextMove + this.options.tooltipTextDelete, {direction:'top', opacity:0.7, className:'polyline-measure-popupTooltip'});
                 this._currentLine.circleMarkers.last().setStyle (this.options.currentCircle);
                 this._cntCircle = this._currentLine.circleCoords.length;
+                this._map.fire('polylinemeasure:resume', this._currentLine);
             }
         },
 
@@ -1056,6 +1061,7 @@
                         this._updateTooltip (item, prevTooltip, totalDistance, distance, lastCircleCoords, mouseCoords);
                     }
                 }.bind(this));
+              this._map.fire('polylinemeasure:insert', e);
             }
         },
 
@@ -1071,6 +1077,7 @@
             this._map.dragging.enable();
             this._map.on ('mousemove', this._mouseMove, this);
             this._map.off ('mouseup', this._dragCircleMouseup, this);
+            this._map.fire('polylinemeasure:move', this._e1);
         },
 
         _dragCircleMousemove: function (e2) {
@@ -1243,6 +1250,7 @@
                       this._layerPaint.removeLayer (this._arrPolylines[lineNr].tooltips [0]);
                       this._layerPaint.removeLayer (this._arrPolylines[lineNr].arrowMarkers [0]);
                       this._layerPaint.removeLayer (this._arrPolylines[lineNr].polylinePath);
+                      this._map.fire('polylinemeasure:remove', e1);
                       return;
                     }
                     
@@ -1406,6 +1414,7 @@
 	                this._currentLine.distance = totalDistanceUnfinishedLine;
                 }
 
+                this._map.fire('polylinemeasure:remove', e1);
                 return;
             }
             this._e1 = e1;

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 * Leaflet Plugin to **measure distances** of simple lines as well as of complex polylines.
 * Measuring in **metric system** (metre, kilometre), in **imperial system** (foot, landmile), or in **nautical miles**.
 * Lines are drawn as realistic arcs. **Bearings** and **distances** are calculated considering [**Great-circle distance**](https://en.wikipedia.org/wiki/Great-circle_distance) which is the shortest path between 2 points on Earth.
-* **Arrows** indicating the **real midways** of the line's great-circle **distances**, not their optical middle which is different due to projection, especially in high latitudes. 
+* **Arrows** indicating the **real midways** of the line's great-circle **distances**, not their optical middle which is different due to projection, especially in high latitudes.
 * To **finish** drawing a line just *doubleclick*, or *singleclick* onto the last (=orange) point, or *press "ESC"-key*.
 * **Moving** of line's points afterwards is possible by clicking and draging them. *(This feature can not be guaranteed to work on every **mobile** browser using touch input, e.g. with Chrome Mobile it isn't working right now)*
 * To **continue** a line after it has been finished, hold the *Ctrl-Key* while clicking onto the first or last point of a line.
@@ -29,27 +29,10 @@ Add 1 code line within your **Javascript-file** to add the plugin's control into
 ```js
 L.control.polylineMeasure(options).addTo(map);
 ```
-### Events
-It fire some events during the measure in order to allow more interactivity with the app.
-Subscribe to events with :
-
-```js
-map.on('polylinemeasure:toogle', e => { /* e.sttus */ });
-map.on('polylinemeasure:start', currentLine => {...});
-map.on('polylinemeasure:resume', currentLine => {...});
-map.on('polylinemeasure:finish', currentLine => {...});
-map.on('polylinemeasure:clear', e => {...});
-map.on('polylinemeasure:add', e => { /* e.latlng */ });
-map.on('polylinemeasure:insert', e => { /* e.latlng */ });
-map.on('polylinemeasure:move', e => { /* e.latlng ; e.sourceTarget._latlng */ });
-map.on('polylinemeasure:remove', e => { /* e.latlng ; e.sourceTarget._latlng */ });
-```
-
-* Please take a look at [**Demo 1**](https://ppete2.github.io/Leaflet.PolylineMeasure/demo1.html) each event is printed in the console.
 
 ## Package manager install
 
-It's possible to install and update this plugin using package managers like `npm`. These optional feature got added by other users. I'm not familiar with nor responsible to keep these optional package manager installs up-to-date. If you notice that such installs are outdated, feel free to provide a Pull request or contact one of the persons who once introduced those install variants, thanks. 
+It's possible to install and update this plugin using package managers like `npm`. These optional feature got added by other users. I'm not familiar with nor responsible to keep these optional package manager installs up-to-date. If you notice that such installs are outdated, feel free to provide a Pull request or contact one of the persons who once introduced those install variants, thanks.
 
 ## Default options
 
@@ -128,3 +111,21 @@ options = {
     },
 };
 ```
+
+## Events
+It fire some events during the measure in order to allow more interactivity with the app.
+Subscribe to events with :
+
+```js
+map.on('polylinemeasure:toogle', e => { /* e.sttus */ });
+map.on('polylinemeasure:start', currentLine => {...});
+map.on('polylinemeasure:resume', currentLine => {...});
+map.on('polylinemeasure:finish', currentLine => {...});
+map.on('polylinemeasure:clear', e => {...});
+map.on('polylinemeasure:add', e => { /* e.latlng */ });
+map.on('polylinemeasure:insert', e => { /* e.latlng */ });
+map.on('polylinemeasure:move', e => { /* e.latlng ; e.sourceTarget._latlng */ });
+map.on('polylinemeasure:remove', e => { /* e.latlng ; e.sourceTarget._latlng */ });
+```
+
+* Please take a look at [**Demo 1**](https://ppete2.github.io/Leaflet.PolylineMeasure/demo1.html) each event is printed in the console.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ Add 1 code line within your **Javascript-file** to add the plugin's control into
 ```js
 L.control.polylineMeasure(options).addTo(map);
 ```
+### Events
+It fire some events during the measure in order to allow more interactivity with the app.
+Subscribe to events with :
+
+```js
+map.on('polylinemeasure:toogle', e => { /* e.sttus */ });
+map.on('polylinemeasure:start', currentLine => {...});
+map.on('polylinemeasure:resume', currentLine => {...});
+map.on('polylinemeasure:finish', currentLine => {...});
+map.on('polylinemeasure:clear', e => {...});
+map.on('polylinemeasure:add', e => { /* e.latlng */ });
+map.on('polylinemeasure:insert', e => { /* e.latlng */ });
+map.on('polylinemeasure:move', e => { /* e.latlng ; e.sourceTarget._latlng */ });
+map.on('polylinemeasure:remove', e => { /* e.latlng ; e.sourceTarget._latlng */ });
+```
+
+* Please take a look at [**Demo 1**](https://ppete2.github.io/Leaflet.PolylineMeasure/demo1.html) each event is printed in the console.
 
 ## Package manager install
 

--- a/demo1.html
+++ b/demo1.html
@@ -13,14 +13,30 @@
             html, body, #map {height: 100%;}
         </style>
     </head>
-    
+
     <body>
         <div id="map"></div>
         <script>
             var layerOsm = new L.TileLayer ('https://{s}.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}', {subdomains:['server','services'], maxZoom:19, noWrap:false, attribution:'<a href="https://www.arcgis.com/">ArcGIS</a>' });
             var map = new L.Map ('map').addLayer (layerOsm).setView (new L.LatLng(48, 0), 4);
             L.control.scale ({maxWidth:240, metric:true, imperial:false, position: 'bottomleft'}).addTo (map);
-            L.control.polylineMeasure ({position:'topleft', unit:'metres', showBearings:true, clearMeasurementsOnStop: false, showClearControl: true, showUnitControl: true}).addTo (map);
-        </script>    
+            let polylineMeasure = L.control.polylineMeasure ({position:'topleft', unit:'metres', showBearings:true, clearMeasurementsOnStop: false, showClearControl: true, showUnitControl: true})
+            polylineMeasure.addTo (map);
+
+            function debugevent(e) { console.debug(e.type, e, polylineMeasure._currentLine) }
+
+            map.on('polylinemeasure:toggle', debugevent);
+            map.on('polylinemeasure:start', debugevent);
+            map.on('polylinemeasure:resume', debugevent);
+            map.on('polylinemeasure:finish', debugevent);
+            map.on('polylinemeasure:clear', debugevent);
+            map.on('polylinemeasure:add', debugevent);
+            map.on('polylinemeasure:insert', debugevent);
+            map.on('polylinemeasure:move', debugevent); // TODO
+            map.on('polylinemeasure:remove', debugevent); // TODO
+
+
+
+        </script>
     </body>
 </html>

--- a/demo1.html
+++ b/demo1.html
@@ -32,10 +32,8 @@
             map.on('polylinemeasure:clear', debugevent);
             map.on('polylinemeasure:add', debugevent);
             map.on('polylinemeasure:insert', debugevent);
-            map.on('polylinemeasure:move', debugevent); // TODO
-            map.on('polylinemeasure:remove', debugevent); // TODO
-
-
+            map.on('polylinemeasure:move', debugevent);
+            map.on('polylinemeasure:remove', debugevent);
 
         </script>
     </body>


### PR DESCRIPTION
Hi there,

I finaly got to a PR on this feature. 
There is the code, the demo, and the README.

things are quite simple, I just had to decide which object will be sent in the event, I ended with :
* nothing for the toggle and clear event
* the current polyline for start, finish & resume
* the mouse event for add, move, remove, insert 

I tested it in browser, so there is maybe some edge case not tested.