### PR TITLE
Add unitControlClasses to be consistent with clearControl/measurementControl

### DIFF
--- a/Leaflet.PolylineMeasure.js
+++ b/Leaflet.PolylineMeasure.js
@@ -165,6 +165,13 @@
                nauticalmiles: 'nm'
             },
             /**
+             * Classes to apply to the Unit control
+             * @type {Array}
+             * @default
+             */
+            unitControlClasses: [],
+
+            /**
              * Styling settings for the temporary dashed rubberline
              * @type {Object}
              */
@@ -420,7 +427,7 @@
                     var label = this.options.unitControlLabel.nauticalmiles;
                     var title = this.options.unitControlTitle.text + " [" + this.options.unitControlTitle.nauticalmiles  + "]";
                 }
-                var classes = [];
+                var classes = this.options.unitControlClasses;
                 this._unitControl = this._createControl (label, title, classes, this._container, this._changeUnit, this);
                 this._unitControl.setAttribute ('id', 'unitControlId');
             }


### PR DESCRIPTION
There should be a unitControlClasses option for making use of this plugin to be able to add custom classes to the unitControl. 

Such options already exist for the measurementControl and the clearControl, but not for the unitControl. 
Therefore, to be consistent, the unitControl should have this option as well. 

This PR introduces the unitControlClasses option.

If this PR were to be accepted, I would appreciate it if the npm package could be updated after the PR is applied.