### PR TITLE
Fix addPoint() for _arcpoints==2

### DIFF
--- a/Leaflet.PolylineMeasure.js
+++ b/Leaflet.PolylineMeasure.js
@@ -886,12 +886,12 @@
                     // update polyline
                     if (this.circleCoords.length > 1) {
                         var arc = polylineState._polylineArc (lastCircleCoords, mouseCoords);
+                        var arrowMarker = polylineState._drawArrow (arc);
                         if (this.circleCoords.length > 2) {
                             arc.shift();  // remove first coordinate of the arc, cause it is identical with last coordinate of previous arc
                         }
                         this.polylinePath.setLatLngs (this.polylinePath.getLatLngs().concat(arc));
                         // following lines needed especially for Mobile Browsers where we just use mouseclicks. No mousemoves, no tempLine.
-                        var arrowMarker = polylineState._drawArrow (arc);
                         arrowMarker.cntLine = polylineState._currentLine.id;
                         arrowMarker.cntArrow = polylineState._cntCircle - 1;
                         polylineState._currentLine.arrowMarkers.push (arrowMarker);

--- a/Leaflet.PolylineMeasure.js
+++ b/Leaflet.PolylineMeasure.js
@@ -2,7 +2,7 @@
 **                                                      **
 **       Leaflet Plugin "Leaflet.PolylineMeasure"       **
 **       File "Leaflet.PolylineMeasure.js"              **
-**       Date: 2022-10-07                               **
+**       Date: 2022-10-31                               **
 **                                                      **
 *********************************************************/
 


### PR DESCRIPTION
Hi, I added your measurement tool to my [map of the Game Boy chip](http://iceboy.a-singer.de/dmg_cpu_b_map/). Of course I had to modify it a bit, because I don't need arcs, because microchips are not spherical usually.

While doing that, I ran into the issue with the corner case when you set `_arcpoints` to `2`, it is unable to draw the arrow in the `addPoint` function. This is because the first point of an arc always gets removed (except for the very first arc). Then with only one point left, the `_drawArrow` function can't calculate a midpoint (P2 is unset). This can be easily fixed by moving the call to `_drawArrow` a few lines up, so it is called before the first point is removed.