### PR TITLE
fix macOS-related tooltips

### DIFF
--- a/Leaflet.PolylineMeasure.js
+++ b/Leaflet.PolylineMeasure.js
@@ -2,7 +2,7 @@
 **                                                      **
 **       Leaflet Plugin "Leaflet.PolylineMeasure"       **
 **       File "Leaflet.PolylineMeasure.js"              **
-**       Date: 2022-12-27                               **
+**       Date: 2022-12-28                               **
 **                                                      **
 *********************************************************/
 
@@ -86,8 +86,8 @@
             tooltipTextFinish: 'Click to <b>finish line</b><br>',
             tooltipTextDelete: 'Press SHIFT-key and click to <b>delete point</b>',
             tooltipTextMove: 'Click and drag to <b>move point</b><br>',
-            tooltipTextResume: '<br>Press ' + isMacOS ? '⌘' : 'CTRL-key' + ' and click to <b>resume line</b>',
-            tooltipTextAdd: 'Press ' + isMacOS ? '⌘' : 'CTRL-key' + ' and click to <b>add point</b>',
+            tooltipTextResume: '<br>Press ' + (isMacOS ? '⌘' : 'CTRL-key') + ' and click to <b>resume line</b>',
+            tooltipTextAdd: 'Press ' + (isMacOS ? '⌘' : 'CTRL-key') + ' and click to <b>add point</b>',
 
             /**
              * Title for the control going to be switched on


### PR DESCRIPTION
add braces for ternary operators to fix string concatenations

before:

<img width="456" alt="изображение" src="https://user-images.githubusercontent.com/846774/209750496-1599bbd0-69b9-4af2-93b2-5d4910882a5e.png">

<img width="397" alt="изображение" src="https://user-images.githubusercontent.com/846774/209750502-45f9955a-2fff-48ac-8876-efb72eaaa338.png">

after:

> Press SHIFT-key and click to **delete point**

> Press ⌘ and click to **add point**