### PR TITLE
feat(centimeters): Display decimals on meters

### DIFF
--- a/Leaflet.PolylineMeasure.js
+++ b/Leaflet.PolylineMeasure.js
@@ -662,7 +662,7 @@
                     if (!this.options.useSubunits) {
                         dist = (dist/1000).toFixed(3);
                     } else {
-                        dist = (dist).toFixed(0);
+                        dist = (dist).toFixed(2);
                         unit = this.options.unitControlLabel.metres;
                     }
                 }


### PR DESCRIPTION
- When measuring with meters, display two decimals to indicate centimeter distance
It popped up as scenario and thought to share it with you