### PR TITLE
Add option to use Rhumb lines

### DIFF
--- a/Leaflet.PolylineMeasure.js
+++ b/Leaflet.PolylineMeasure.js
@@ -777,7 +777,6 @@
 
         /**
          * Update the tooltip distance
-         * @TODO param details
          * @param currentTooltip        Current tooltip
          * @param prevTooltip           Previous tooltip
          * @param {Number} total        Total distance
@@ -1163,8 +1162,6 @@
 
                 // get Coords of each Point of the current Polyline
                 var lineCoords = this._arrPolylines[lineNr].polylinePath.getLatLngs();
-                // TODO: GC uses 0/1 whereas rhumbLines use lat/lng for some reason ... debug/standardise if necessary
-                //console.log('lineCoords 1', lineCoords);
 
                 // generate coords up to this point
                 var arc1 = this._generateLineCoords (this._arrPolylines[lineNr].circleCoords[arrowNr], e.latlng);

--- a/Leaflet.PolylineMeasure.js
+++ b/Leaflet.PolylineMeasure.js
@@ -598,8 +598,6 @@
             const φ2 = _to.lat * Math.PI / 180;
             const Δφ = φ2 - φ1;
             let Δλ = Math.abs(_to.lng - _from.lng) * Math.PI / 180;
-            // if dLon over 180° take shorter rhumb line across the anti-meridian:
-            if (Math.abs(Δλ) > Math.PI) Δλ = Δλ > 0 ? -(2 * Math.PI - Δλ) : (2 * Math.PI + Δλ);
 
             // on Mercator projection, longitude distances shrink by latitude; q is the 'stretch factor'
             // q becomes ill-conditioned along E-W line (0/0); use empirical tolerance to avoid it (note ε is too small)
@@ -859,9 +857,6 @@
 
                 var y = Math.log(Math.tan(Math.PI/4+lat2/2)/Math.tan(Math.PI/4+lat1/2));
                 var x = lng2 - lng1;
-
-                // if dLon over 180° take shorter rhumb line across the anti-meridian:
-                if (Math.abs(x) > Math.PI) x = x>0 ? -(2*Math.PI-x) : (2*Math.PI+x);
 
                 if (direction === "inbound") {
                     var brng = Math.atan2(x, y) * 180/Math.PI - 180;

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - [**Demo 3**](https://ppete2.github.io/Leaflet.PolylineMeasure/demo3.html) (nautical mile units, bearings, without Unit Control and Clear Control buttons)
 - [**Demo 4**](https://ppete2.github.io/Leaflet.PolylineMeasure/demo4.html) (two maps)
 - [**Demo 5**](https://ppete2.github.io/Leaflet.PolylineMeasure/demo5.html) (programatically providing polyline points - "Seeding Data")
+- [**Demo 6**](https://ppete2.github.io/Leaflet.PolylineMeasure/demo6.html) (using simple rhumb lines instead of great circles)
 
 ![Screenshot](https://ppete2.github.io/Leaflet.PolylineMeasure/screenshot.jpg)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * Measuring in **metric system** (metres, kilometres), in **imperial system** (feet, landmiles), or in **nautical miles**.
 * Lines are drawn as realistic arcs. **Bearings** and **distances** are calculated considering [**Great-circle distance**](https://en.wikipedia.org/wiki/Great-circle_distance) which is the shortest path between 2 points on Earth.
 * **Arrows** indicating the **real midways** of the line's great-circle **distances**, not their optical middle which is different due to projection, especially in high latitudes.
-* Lines can be displayed as straight rhumb lines instead of great circle arcs if preferred.
+* Lines can be displayed as straight **rhumb lines** instead of great-circle arcs if preferred.
 * To **finish** drawing a line just *doubleclick*, or *singleclick* onto the last (=orange) point, or *press "ESC"-key*.
 * **Moving** of line's points afterwards is possible by clicking and draging them. *(This feature can not be guaranteed to work on every **mobile** browser using touch input, e.g. with Chrome Mobile it isn't working right now)*
 * To **continue** a line after it has been finished, hold the *Ctrl-Key* while clicking onto the first or last point of a line.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 * Measuring in **metric system** (metres, kilometres), in **imperial system** (feet, landmiles), or in **nautical miles**.
 * Lines are drawn as realistic arcs. **Bearings** and **distances** are calculated considering [**Great-circle distance**](https://en.wikipedia.org/wiki/Great-circle_distance) which is the shortest path between 2 points on Earth.
 * **Arrows** indicating the **real midways** of the line's great-circle **distances**, not their optical middle which is different due to projection, especially in high latitudes.
+* Lines can be displayed as straight rhumb lines instead of great circle arcs if preferred.
 * To **finish** drawing a line just *doubleclick*, or *singleclick* onto the last (=orange) point, or *press "ESC"-key*.
 * **Moving** of line's points afterwards is possible by clicking and draging them. *(This feature can not be guaranteed to work on every **mobile** browser using touch input, e.g. with Chrome Mobile it isn't working right now)*
 * To **continue** a line after it has been finished, hold the *Ctrl-Key* while clicking onto the first or last point of a line.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ options = {
     useSubunits: true,              // Use subunits (metres/feet) in tooltips if distances are less than 1 kilometre/landmile
     clearMeasurementsOnStop: true,  // Clear all measurements when Measure Control is switched off
     showBearings: false,            // Whether bearings are displayed within the tooltips
+    useRhumbLines: false,           // Whether to use simple rhumb lines instead of great circle measurements
+    arcpoints: 99,                  // Number of points to draw in each arc (when using default great circle method)
     bearingTextIn: 'In',            // language dependend label for inbound bearings
     bearingTextOut: 'Out',          // language dependend label for outbound bearings
     tooltipTextFinish: 'Click to <b>finish line</b><br>',

--- a/demo6.html
+++ b/demo6.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Demo 6 of Leaflet.PolylineMeasure</title>
+        <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+        <link rel="stylesheet" href="Leaflet.PolylineMeasure.css" />
+        <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+        <script src="Leaflet.PolylineMeasure.js"></script>
+        <style>
+            body {padding: 0; margin: 0;}
+            html, body, #map {height: 100%;}
+        </style>
+    </head>
+
+    <body>
+        <div id="map"></div>
+        <script>
+            var layerOsm = new L.TileLayer ('https://{s}.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}', {subdomains:['server','services'], maxZoom:19, noWrap:false, attribution:'<a href="https://www.arcgis.com/">ArcGIS</a>' });
+            var map = new L.Map ('map').addLayer (layerOsm).setView (new L.LatLng(48, 0), 4);
+            L.control.scale ({maxWidth:240, metric:true, imperial:false, position: 'bottomleft'}).addTo (map);
+            let polylineMeasure = L.control.polylineMeasure ({position:'topleft', unit:'kilometres', showBearings:true, clearMeasurementsOnStop: false, showClearControl: true, showUnitControl: true, useRhumbLines: true})
+            polylineMeasure.addTo (map);
+
+            function debugevent(e) { console.debug(e.type, e, polylineMeasure._currentLine) }
+
+            map.on('polylinemeasure:toggle', debugevent);
+            map.on('polylinemeasure:start', debugevent);
+            map.on('polylinemeasure:resume', debugevent);
+            map.on('polylinemeasure:finish', debugevent);
+            map.on('polylinemeasure:change', debugevent);
+            map.on('polylinemeasure:clear', debugevent);
+            map.on('polylinemeasure:add', debugevent);
+            map.on('polylinemeasure:insert', debugevent);
+            map.on('polylinemeasure:move', debugevent);
+            map.on('polylinemeasure:remove', debugevent);
+
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
This pull request adds an option to use straight rhumb lines (and their equivalent bearing) instead of great circle lines. It's still useful in maritime navigation for example, even if it's not the most direct route. It's similar to the way the original [leaflet.measure](https://github.com/jtreml/leaflet.measure) plugin worked.

The calculations are based on the [handy website](http://www.movable-type.co.uk/scripts/latlong.html) used for the other calculations.

As part of the update I've moved the `arcpoints` variable into the options array to allow it to be modified. It needs overriding when using rhumb lines, but this PR also then fixes the bearings and midpoint arrow placement compared to just setting the original _arcpoints variable to 2.